### PR TITLE
Add tech stack details for AIElasticAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ I build tools that orchestrate infrastructure, makes cloud migrations easier, an
 AIElasticAgent turns natural-language requests into ready-to-use Kibana dashboards.
 Describe the visualizations, filters, and metrics you want, and the agent assembles the layout automatically using Elastic APIs.
 
+**Stack:** Python 🐍 | LangChain 🧩 | Elasticsearch 🔍 | Kibana 📊 | OpenAI SDK 🤖
+
 </td>
 <td width="50%" valign="top">
 


### PR DESCRIPTION
## Summary
- add the AIElasticAgent tech stack entry so it matches the other featured projects

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d3740ebb888332a589118d40459d7a